### PR TITLE
Fix Eid mapping

### DIFF
--- a/src/main/java/de/interactive_instruments/etf/client/internal/EidObjectMappingBuilder.java
+++ b/src/main/java/de/interactive_instruments/etf/client/internal/EidObjectMappingBuilder.java
@@ -16,8 +16,8 @@
  */
 package de.interactive_instruments.etf.client.internal;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.json.JSONObject;
 
@@ -29,7 +29,7 @@ class EidObjectMappingBuilder {
     private final Map<String, JSONObject> idObjMap;
 
     EidObjectMappingBuilder() {
-        this.idObjMap = new HashMap<>();
+        this.idObjMap = new ConcurrentHashMap<>();
     }
 
     void add(final JSONObject obj) {


### PR DESCRIPTION
I occasionally got an error when generating the response objects due to `java.lang.NullPointerException: Object with EID EID81f1023e-e8ce-3c42-a729-cfc9d89f44c0 not found` (or a different ID). Running the same test with the same test resource over and over again only sometimes produced this issue.

Example stack trace excerpt:

```
Caused by: java.lang.NullPointerException: Object with EID EID15da60a6-d229-382c-9ac2-a32eac4d637d not found
        at java.util.Objects.requireNonNull(Objects.java:233) ~[?:?]
        at de.interactive_instruments.etf.client.internal.EidObjectMapping.resolve(EidObjectMapping.java:36) ~[etf-client-1.8.0.jar:1.8.0]
        at de.interactive_instruments.etf.client.internal.AbstractResult.<init>(AbstractResult.java:103) ~[etf-client-1.8.0.jar:1.8.0]
        at de.interactive_instruments.etf.client.internal.AbstractTestResultMessageHolder.<init>(AbstractTestResultMessageHolder.java:37) ~[etf-client-1.8.0.jar:1.8.0]
        at de.interactive_instruments.etf.client.internal.TestStepResultImpl.<init>(TestStepResultImpl.java:37) ~[etf-client-1.8.0.jar:1.8.0]
        at de.interactive_instruments.etf.client.internal.TestCaseResultImpl.doCreateChild(TestCaseResultImpl.java:95) ~[etf-client-1.8.0.jar:1.8.0]
        at de.interactive_instruments.etf.client.internal.TestCaseResultImpl.createTestStepResults(TestCaseResultImpl.java:56) ~[etf-client-1.8.0.jar:1.8.0]
        at de.interactive_instruments.etf.client.internal.TestCaseResultImpl.<init>(TestCaseResultImpl.java:44) ~[etf-client-1.8.0.jar:1.8.0]
        at de.interactive_instruments.etf.client.internal.TestModuleResultImpl.doCreateChild(TestModuleResultImpl.java:43) ~[etf-client-1.8.0.jar:1.8.0]
```

From reading the code I'm unsure how this can happen, I assume that this has to do with other threads also accessing the map. This PR appears to fix this.

@jonherrmann If this gets merged, can you provide a new release with this fix?